### PR TITLE
Updated _linkedToId in example.json

### DIFF
--- a/example.json
+++ b/example.json
@@ -5,7 +5,7 @@
     "_component":"linkedConfidenceSlider",
     "_classes":"",
     "_layout":"right",
-    "_linkedTo": "c-135",
+    "_linkedToId": "c-135",
     "title": "Linked Confidence Slider",
     "displayTitle": "Linked Confidence Slider",
     "disabledBody": "You need to measure your confidence in the linked part before you can do this part.",


### PR DESCRIPTION
Was previously “_linkedTo”. Referenced as “_linkedToId” line 42 of
adapt-contrib-linkedConfidenceSlider.js
